### PR TITLE
Add MacOS (Darwin) build

### DIFF
--- a/BUILD.sh
+++ b/BUILD.sh
@@ -25,6 +25,7 @@ build() {
   echo "Compiling ruckstack..."
   (export GOOS=windows && go build -o out/dist/win/bin/ruckstack.exe cmd/ruckstack/main.go)
   (export GOOS=linux && go build -o out/dist/linux/ruckstack/bin/ruckstack cmd/ruckstack/main.go)
+  (export GOOS=darwin && go build -o out/dist/darwin/ruckstack/bin/ruckstack cmd/ruckstack/main.go)
 
   echo "Creating windows distribution..."
   cp ./LICENSE out/dist/win
@@ -37,6 +38,11 @@ build() {
   chmod 755 out/dist/linux/ruckstack/bin/ruckstack
   (cd out/dist/linux && tar cfz ../../ruckstack-linux-${VERSION}.tgz ruckstack)
 
+  echo "Creating darwin (macos) distribution..."
+  cp ./LICENSE out/dist/darwin/ruckstack
+  cp -r dist out/dist/darwin/ruckstack
+  chmod 755 out/dist/darwin/ruckstack/bin/ruckstack
+  (cd out/dist/darwin && tar cfz ../../ruckstack-darwin-${VERSION}.tgz ruckstack)
 
   echo "Done"
 }


### PR DESCRIPTION
Following on from #39 I thought I would try and add this.

May need more thorough testing but it compiles and runs:

```sh
❯ ./BUILD.sh
Building ruckstack 0.8.3...
Compiling system-control...
Compiling installer...
Collecting ruckstack resources...
Compiling ruckstack...
Creating windows distribution...
Creating linux distribution...
Creating darwin (macos) distribution...
Done

./out/dist/darwin/ruckstack/bin/ruckstack
Ruckstack CLI

Usage:
  ruckstack [command]

Available Commands:
  build       Builds project
  helm        Commands for interacting with the Helm repository
  help        Help about any command
  new-project Sets up a new project config in the current directory

Flags:
  -h, --help      help for ruckstack
  -v, --version   version for ruckstack

Use "ruckstack [command] --help" for more information about a command.
```